### PR TITLE
fix: getProviderAsync return type

### DIFF
--- a/src/ip2proxy.d.ts
+++ b/src/ip2proxy.d.ts
@@ -415,7 +415,7 @@ export class IP2Proxy {
      * @param myIP The IP address to query.
      * @returns The promise of the name of the VPN provider.
      */
-    getProviderAsync(myIP: string): Provider<string>;
+    getProviderAsync(myIP: string): Promise<string>;
     /**
      * Returns all fields.
      *


### PR DESCRIPTION
The current return type of the function `getProviderAsync` has a non existing type called `Provider<string>` instead of the expected one of `Promise<string>`.
This pull fixes this issue an makes the library work with typescript again.